### PR TITLE
Andie updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 .pyc
 __pycache__/
 docs/
+.python-version

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ __pycache__
 .pyc
 __pycache__/
 docs/
-.python-version

--- a/src/chapters/auth/user-model.rst
+++ b/src/chapters/auth/user-model.rst
@@ -14,6 +14,11 @@ Before we can authenticate users, we need users to authenticate! We'll start by 
 A ``User`` Model
 ----------------------
 
+.. admonition:: Note
+
+   You can use the `add-tags branch <https://github.com/LaunchCodeEducation/coding-events/tree/add-tags>`_ as your starting point for this section. 
+
+
 A model class representing users needs, at a minimum, fields representing username and password.
 
 In the ``models`` package, create a ``User`` class with ``@Entity`` and extending ``AbstractEntity``. It should have two string fields, ``username`` and ``pwHash``. We only need a getter for ``username``.
@@ -123,7 +128,7 @@ Spring allows for additional, custom methods to be added to repository interface
 
 .. admonition:: Note
 
-	The code for this section is available in the 
+	The final code for this section is available in the 
 	`user-model branch <https://github.com/LaunchCodeEducation/coding-events/tree/user-model>`_ 
 	of the ``coding-events-demo`` repository.
 

--- a/src/chapters/enums/exercises.rst
+++ b/src/chapters/enums/exercises.rst
@@ -7,7 +7,7 @@ Exercises: Enum Practice
 
 #. Use the *Get from Version Control* option to open the project in IntelliJ.
 
-#. In the project, navigate to the data package.
+#. In the project, create a data package.
 
 #. Create a new public enum called ``Planets``.
 

--- a/src/chapters/orm-part1/accessing-data.rst
+++ b/src/chapters/orm-part1/accessing-data.rst
@@ -94,7 +94,9 @@ The accompanying text is a quick rundown of what happens in the video. To get st
 
    The starter code for this video is found at the `db-config branch <https://github.com/LaunchCodeEducation/coding-events/tree/db-config>`__ of the ``coding-events-demo`` repo. 
    The final code presented in this video is found on the `persistent-model branch <https://github.com/LaunchCodeEducation/coding-events/tree/persistent-model>`__. As always, code along to the 
-   videos on your own ``coding-events`` project.
+   videos on your own ``coding-events`` project. 
+   
+   Remember when switching branches to update your ``application.properties`` file to reflect your schema and authentication settings.
 
 Creating Persistent Models - Text
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Small updates to the following sections for clarity:

1. [Enum practice exercises](https://education.launchcode.org/java-web-development/chapters/enums/exercises.html): there is no data package on the starting/main branch, so changed wording to make it clear students should create one.
2. [Intro to ORM](https://education.launchcode.org/java-web-development/chapters/orm-part1/accessing-data.html#creating-persistent-models-video): because it trips students up, add a small reminder that when students switch branches they need to update the application.properties file to reflect their local MySQL workbench settings.
3. [Authentication](https://education.launchcode.org/java-web-development/chapters/auth/user-model.html): there was no starting branch explicitly mentioned, so I gave them the previous complete branch as their starting point to avoid confusion.