### PR TITLE
fixed typo/syntax error

### DIFF
--- a/src/chapters/data-types/more-data-types.rst
+++ b/src/chapters/data-types/more-data-types.rst
@@ -153,7 +153,7 @@ address* of the object, which we visualize as an arrow pointing from the
 variable box to where the data is stored. Instead of holding the actual ``Cat``
 data, ``myCat`` stores *directions* for finding the data in memory.
 
-When we to assign ``myCat`` to another variable, as in ``Cat sameCat = myCat``,
+When we assign ``myCat`` to another variable, as in ``Cat sameCat = myCat``,
 we do NOT create a second copy of the object or its data. Instead, we make a
 second arrow pointing to the same memory location.
 


### PR DESCRIPTION
Changed "When we to assign" to "When we assign." 

A second grammatically correct option is "Were we to assign," but that requires changing the tense of the rest of the sentence: 

"*Were* we to assign myCat to another variable, as in Cat sameCat = myCat, we *would* NOT create a second copy of the object or its data. Instead, we *would* make a second arrow pointing to the same memory location.