### PR TITLE
Fix typos in questions

### DIFF
--- a/src/chapters/spring-controllers-and-routes/controllers-parameters.rst
+++ b/src/chapters/spring-controllers-and-routes/controllers-parameters.rst
@@ -121,11 +121,12 @@ Check Your Understanding
       @GetMapping("venus")
       @ResponseBody
       public String venusSurface(@RequestParam String terrestrial) {
-      if (terrestrial == true) {
-         return "Venus is rocky."        
-      } else {
-         return "Venus is gaseous."
-      }
+	if (terrestrial.equals("true")) {
+	    return "Venus is rocky.";        
+	 } else {
+	    return "Venus is gaseous.";
+	 }
+	}
  
    a. ``myfavoriteplanets.net/venus?terrestrial=true``
       
@@ -148,7 +149,7 @@ Check Your Understanding
       @GetMapping("venus/{orbiter}")
       @ResponseBody
       public String venusOrbiter(@PathVariable String orbiter) {
-         return orbiter + " currently orbits Venus."
+         return orbiter + " currently orbits Venus.";
       }
 
    a. ``myfavoriteplanets.net/venus/{Akatsuki}``


### PR DESCRIPTION
There were some missing ";", the indentation was not correct in the first question. "==" was used to compare the strings.